### PR TITLE
Sysinfo m version

### DIFF
--- a/src/logbook/sysinfo.py
+++ b/src/logbook/sysinfo.py
@@ -1,9 +1,15 @@
 import os
 import argparse
 
-class Data(dict):
+class _Data(dict):
+    def __init__(self, mistake_allowed=True):
+        self.mistake_allowed = mistake_allowed
+
     def __getattr__(self, name):
-        return self.__getitem__(name)
+        if self.mistake_allowed:
+            return self.get(name)
+        else:
+            return self[name]
 
 class Sysinfo():
     def __init__(self, log):
@@ -12,16 +18,40 @@ class Sysinfo():
         self.process()
         pass
 
+    def __repr__(self):
+        print(f'{self.data.sys} \n {self.data.exe}')
+    
+    def __str__(self):
+        return f'{self.data.sys} \n {self.data.exe}'
+
     def process(self):
-        self.data = Data()
+        """Provides access 
+        to args - self.data.exe['key']
+        to sys_env  - self.data.sys['key'] """
+
+        self.data = _Data(mistake_allowed=False)
+        self.data['sys'] = _Data()
+        self.data['exe'] = _Data()
+
         for key, value in os.environ.items():
-            self.data[key] = value
+            self.data.sys[key] = value
+
         self.args, anons = self.parser.parse_known_args()
         for item in anons:
             try:
                 key, value = item.split('=')
             except ValueError:
-                pass
+                msg =f"""Error parsing {item}.
+                Make sure form is "key=value" """
+                raise ValueError(msg)
             else:
-                self.data[key] = value
+                self.data.exe[key] = value
         pass
+
+
+def test():
+    c = Sysinfo('test')
+    print(c)
+
+if __name__ == '__main__':
+    test()


### PR DESCRIPTION
Set vars to 2 caregories - EXE (args), SYS (os, env)
Created interface, example: self.data.sys.WINDIR, self.data.exe.a